### PR TITLE
Uses shorter property names and encourages hyphen-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,22 @@ You may then delete the jar itself.
 Download the latest zipkin-server jar (which is named zipkin.jar) from [here](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec). For more information visit [zipkin-server homepage](https://github.com/openzipkin/zipkin/tree/master/zipkin-server).  
 
 ### 4- create an `application.properties` file for configuration next to the zipkin.jar file
-Populate the configuration - make sure the resources (Azure Storage, Event Hub, etc) exist. **Only storageConnectionString is mandatory** the rest are optional and must be used only to override the defaults:
+Populate the configuration - make sure the resources (Azure Storage, Event Hub, etc) exist.
+
+**zipkin.collector.eventhub.storage.connection-string is mandatory**
+the rest are optional and must be used only to override the defaults:
+
 ```
-zipkin.collector.eventhub.storageConnectionString=<azure storage connection string>
-zipkin.collector.eventhub.eventHubName=<name of the eventhub, default is zipkin>
-zipkin.collector.eventhub.consumerGroupName=<name of the consumer group, default is $Default>
-zipkin.collector.eventhub.storageContainerName=<name of the storage container, default is zipkin>
-zipkin.collector.eventhub.processorHostName=<name of the processor host, default is a randomly generated GUID>
-zipkin.collector.eventhub.storageBlobPrefix=<the path within container where blobs are created for partition lease, processorHostName>
+zipkin.collector.eventhub.name=<name of the eventhub, default is zipkin>
+zipkin.collector.eventhub.consumer-group=<name of the consumer group, default is $Default>
+zipkin.collector.eventhub.processor-host=<name of the processor host, default is a randomly generated GUID>
+zipkin.collector.eventhub.storage.connection-string=<azure storage connection string>
+zipkin.collector.eventhub.storage.container=<name of the storage container, default is zipkin>
+zipkin.collector.eventhub.storage.blob-prefix=<the path within container where blobs are created for partition lease, processorHost>
 ```
 
 ### 5- Run the server along with the collector
 Assuming `zipkin.jar` and `application.properties` are in the current working directory. Note that the EventHub connection string gets passed as a command-line parameter, not from the `application.properties` file:
 ```
-java -Dloader.path=/where/jar/was/unpackaged -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher --spring.config.location=application.properties --zipkin.collector.eventhub.eventHubConnectionString="<eventhub connection string, make sure quoted otherwise won't work>"
+java -Dloader.path=/where/jar/was/unpackaged -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher --spring.config.location=application.properties --zipkin.collector.eventhub.connection-string="<eventhub connection string, make sure quoted otherwise won't work>"
 ```

--- a/autoconfigure/collector-eventhub/src/main/java/zipkin/autoconfigure/collector/eventhub/EventHubCollectorAutoConfiguration.java
+++ b/autoconfigure/collector-eventhub/src/main/java/zipkin/autoconfigure/collector/eventhub/EventHubCollectorAutoConfiguration.java
@@ -46,7 +46,7 @@ public class EventHubCollectorAutoConfiguration {
   }
 
   static final class EventHubSetCondition extends SpringBootCondition {
-    static final String PROPERTY_NAME = "zipkin.collector.eventhub.eventHubConnectionString";
+    static final String PROPERTY_NAME = "zipkin.collector.eventhub.connection-string";
 
     public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata a) {
 

--- a/autoconfigure/collector-eventhub/src/main/java/zipkin/autoconfigure/collector/eventhub/EventHubCollectorProperties.java
+++ b/autoconfigure/collector-eventhub/src/main/java/zipkin/autoconfigure/collector/eventhub/EventHubCollectorProperties.java
@@ -18,55 +18,35 @@ import zipkin.collector.eventhub.EventHubCollector;
 
 @ConfigurationProperties("zipkin.collector.eventhub")
 public class EventHubCollectorProperties {
-
-  private String eventHubName = "zipkin";
-  private String consumerGroupName = "$Default";
-  private String eventHubConnectionString;
-  private String storageConnectionString;
-  private String storageContainerName;
+  private String name = "zipkin";
+  private String consumerGroup = "$Default";
+  private String connectionString;
   private int checkpointBatchSize = 10;
+  private String processorHost;
+  private Storage storage = new Storage();
 
-  private String processorHostName = "";
-  private String storageBlobPrefix = "";
-
-  public String getEventHubName() {
-    return eventHubName;
+  public String getName() {
+    return name;
   }
 
-  public void setEventHubName(String eventHubName) {
-    this.eventHubName = eventHubName;
+  public void setName(String name) {
+    this.name = name;
   }
 
-  public String getConsumerGroupName() {
-    return consumerGroupName;
+  public String getConsumerGroup() {
+    return consumerGroup;
   }
 
-  public void setConsumerGroupName(String consumerGroupName) {
-    this.consumerGroupName = consumerGroupName;
+  public void setConsumerGroup(String consumerGroup) {
+    this.consumerGroup = consumerGroup;
   }
 
-  public String getEventHubConnectionString() {
-    return eventHubConnectionString;
+  public String getConnectionString() {
+    return connectionString;
   }
 
-  public void setEventHubConnectionString(String eventHubConnectionString) {
-    this.eventHubConnectionString = eventHubConnectionString;
-  }
-
-  public String getStorageConnectionString() {
-    return storageConnectionString;
-  }
-
-  public void setStorageConnectionString(String storageConnectionString) {
-    this.storageConnectionString = storageConnectionString;
-  }
-
-  public String getStorageContainerName() {
-    return storageContainerName;
-  }
-
-  public void setStorageContainerName(String storageContainerName) {
-    this.storageContainerName = storageContainerName;
+  public void setConnectionString(String connectionString) {
+    this.connectionString = connectionString;
   }
 
   public int getCheckpointBatchSize() {
@@ -77,49 +57,80 @@ public class EventHubCollectorProperties {
     this.checkpointBatchSize = checkpointBatchSize;
   }
 
-  public String getProcessorHostName() {
-    return processorHostName;
+  public String getProcessorHost() {
+    return processorHost;
   }
 
-  public void setProcessorHostName(String processorHostName) {
-    this.processorHostName = processorHostName;
+  public void setProcessorHost(String processorHost) {
+    this.processorHost = processorHost;
   }
 
-  public String getStorageBlobPrefix() {
-    return storageBlobPrefix;
+  public Storage getStorage() {
+    return storage;
   }
 
-  public void setStorageBlobPrefix(String storageBlobPrefix) {
-    this.storageBlobPrefix = storageBlobPrefix;
+  public void setStorage(
+      Storage storage) {
+    this.storage = storage;
+  }
+
+  public static class Storage {
+    private String connectionString;
+    private String container;
+    private String blobPrefix;
+
+    public String getConnectionString() {
+      return connectionString;
+    }
+
+    public void setConnectionString(String connectionString) {
+      this.connectionString = connectionString;
+    }
+
+    public String getContainer() {
+      return container;
+    }
+
+    public void setContainer(String container) {
+      this.container = container;
+    }
+
+    public String getBlobPrefix() {
+      return blobPrefix;
+    }
+
+    public void setBlobPrefix(String blobPrefix) {
+      this.blobPrefix = blobPrefix;
+    }
   }
 
   public EventHubCollector.Builder toBuilder() {
     EventHubCollector.Builder builder = EventHubCollector.builder()
-        .eventHubConnectionString(eventHubConnectionString)
-        .storageConnectionString(storageConnectionString);
+        .connectionString(connectionString)
+        .storageConnectionString(storage.connectionString);
 
-    if (notEmpty(storageBlobPrefix)) {
-      builder = builder.storageBlobPrefix(storageBlobPrefix);
+    if (notEmpty(getStorage().blobPrefix)) {
+      builder = builder.storageBlobPrefix(storage.blobPrefix);
     }
 
-    if (notEmpty(processorHostName)) {
-      builder = builder.processorHostName(processorHostName);
+    if (notEmpty(processorHost)) {
+      builder = builder.processorHost(processorHost);
     }
 
     if (checkpointBatchSize > 0) {
       builder = builder.checkpointBatchSize(checkpointBatchSize);
     }
 
-    if (notEmpty(consumerGroupName)) {
-      builder = builder.consumerGroupName(consumerGroupName);
+    if (notEmpty(consumerGroup)) {
+      builder = builder.consumerGroup(consumerGroup);
     }
 
-    if (notEmpty(eventHubName)) {
-      builder = builder.eventHubName(eventHubName);
+    if (notEmpty(name)) {
+      builder = builder.name(name);
     }
 
-    if (notEmpty(storageContainerName)) {
-      builder = builder.storageContainerName(storageContainerName);
+    if (notEmpty(getStorage().container)) {
+      builder = builder.storageContainer(storage.container);
     }
 
     return builder;

--- a/autoconfigure/collector-eventhub/src/test/java/zipkin/collector/eventhub/EventHubCollectorAutoConfigurationTest.java
+++ b/autoconfigure/collector-eventhub/src/test/java/zipkin/collector/eventhub/EventHubCollectorAutoConfigurationTest.java
@@ -36,7 +36,7 @@ public class EventHubCollectorAutoConfigurationTest {
 
   AnnotationConfigApplicationContext context;
 
-  static final String dummyEventHubConnectionString =
+  static final String dummyConnectionString =
       "endpoint=sb://someurl.net;SharedAccessKeyName=dumbo;SharedAccessKey=uius7y8ewychsih";
   static final String dummyStorageConnectionString = "UseDevelopmentStorage=true";
 
@@ -49,7 +49,7 @@ public class EventHubCollectorAutoConfigurationTest {
   }
 
   @Test
-  public void doesntProvideCollectorComponent_whenEventHubConnectionStringUnset() {
+  public void doesntProvideCollectorComponent_whenConnectionStringUnset() {
     context = new AnnotationConfigApplicationContext();
     context.register(PropertyPlaceholderAutoConfiguration.class,
         EventHubCollectorProperties.class,
@@ -62,80 +62,80 @@ public class EventHubCollectorAutoConfigurationTest {
   }
 
   @Test
-  public void providesCollectorComponent_whenEventHubConnectionStringIsSet() {
+  public void providesCollectorComponent_whenConnectionStringIsSet() {
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
-        "zipkin.collector.eventhub.eventHubConnectionString:" + dummyEventHubConnectionString);
+        "zipkin.collector.eventhub.connection-string:" + dummyConnectionString);
     addEnvironment(context,
-        "zipkin.collector.eventhub.storageConnectionString:" + dummyStorageConnectionString);
+        "zipkin.collector.eventhub.storage.connection-string:" + dummyStorageConnectionString);
     context.register(PropertyPlaceholderAutoConfiguration.class,
         EventHubCollectorAutoConfiguration.class,
         InMemoryConfiguration.class);
     context.refresh();
 
     EventHubCollectorProperties props = context.getBean(EventHubCollectorProperties.class);
-    assertEquals(dummyEventHubConnectionString, props.getEventHubConnectionString());
-    assertEquals(dummyStorageConnectionString, props.getStorageConnectionString());
+    assertEquals(dummyConnectionString, props.getConnectionString());
+    assertEquals(dummyStorageConnectionString, props.getStorage().getConnectionString());
   }
 
   @Test
-  public void provideCollectorComponent_canSetConsumerGroupName() {
+  public void provideCollectorComponent_canSetConsumerGroup() {
 
-    String consumerGroupName = "pashmak";
+    String consumerGroup = "pashmak";
 
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
-        "zipkin.collector.eventhub.eventHubConnectionString:" + dummyEventHubConnectionString);
+        "zipkin.collector.eventhub.connection-string:" + dummyConnectionString);
     addEnvironment(context,
-        "zipkin.collector.eventhub.storageConnectionString:" + dummyStorageConnectionString);
-    addEnvironment(context, "zipkin.collector.eventhub.consumerGroupName:" + consumerGroupName);
+        "zipkin.collector.eventhub.storage.connection-string:" + dummyStorageConnectionString);
+    addEnvironment(context, "zipkin.collector.eventhub.consumer-group:" + consumerGroup);
     context.register(PropertyPlaceholderAutoConfiguration.class,
         EventHubCollectorAutoConfiguration.class,
         InMemoryConfiguration.class);
     context.refresh();
 
     EventHubCollectorProperties props = context.getBean(EventHubCollectorProperties.class);
-    assertEquals(consumerGroupName, props.getConsumerGroupName());
+    assertEquals(consumerGroup, props.getConsumerGroup());
   }
 
   @Test
-  public void provideCollectorComponent_canSetEventHubName() {
+  public void provideCollectorComponent_canSetName() {
 
-    String eventHubName = "pashmak";
+    String name = "pashmak";
 
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
-        "zipkin.collector.eventhub.eventHubConnectionString:" + dummyEventHubConnectionString);
+        "zipkin.collector.eventhub.connection-string:" + dummyConnectionString);
     addEnvironment(context,
-        "zipkin.collector.eventhub.storageConnectionString:" + dummyStorageConnectionString);
-    addEnvironment(context, "zipkin.collector.eventhub.eventHubName:" + eventHubName);
+        "zipkin.collector.eventhub.storage.connection-string:" + dummyStorageConnectionString);
+    addEnvironment(context, "zipkin.collector.eventhub.name:" + name);
     context.register(PropertyPlaceholderAutoConfiguration.class,
         EventHubCollectorAutoConfiguration.class,
         InMemoryConfiguration.class);
     context.refresh();
 
     EventHubCollectorProperties props = context.getBean(EventHubCollectorProperties.class);
-    assertEquals(eventHubName, props.getEventHubName());
+    assertEquals(name, props.getName());
   }
 
   @Test
-  public void provideCollectorComponent_canSetProcessorHostName() {
+  public void provideCollectorComponent_canSetProcessorHost() {
 
-    String processorHostName = "pashmak";
+    String processorHost = "pashmak";
 
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
-        "zipkin.collector.eventhub.eventHubConnectionString:" + dummyEventHubConnectionString);
+        "zipkin.collector.eventhub.connection-string:" + dummyConnectionString);
     addEnvironment(context,
-        "zipkin.collector.eventhub.storageConnectionString:" + dummyStorageConnectionString);
-    addEnvironment(context, "zipkin.collector.eventhub.processorHostName:" + processorHostName);
+        "zipkin.collector.eventhub.storage.connection-string:" + dummyStorageConnectionString);
+    addEnvironment(context, "zipkin.collector.eventhub.processor-host:" + processorHost);
     context.register(PropertyPlaceholderAutoConfiguration.class,
         EventHubCollectorAutoConfiguration.class,
         InMemoryConfiguration.class);
     context.refresh();
 
     EventHubCollectorProperties props = context.getBean(EventHubCollectorProperties.class);
-    assertEquals(processorHostName, props.getProcessorHostName());
+    assertEquals(processorHost, props.getProcessorHost());
   }
 
   @Test
@@ -145,38 +145,38 @@ public class EventHubCollectorAutoConfigurationTest {
 
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
-        "zipkin.collector.eventhub.eventHubConnectionString:" + dummyEventHubConnectionString);
+        "zipkin.collector.eventhub.connection-string:" + dummyConnectionString);
     addEnvironment(context,
-        "zipkin.collector.eventhub.storageConnectionString:" + dummyStorageConnectionString);
-    addEnvironment(context, "zipkin.collector.eventhub.storageBlobPrefix:" + storageBlobPrefix);
+        "zipkin.collector.eventhub.storage.connection-string:" + dummyStorageConnectionString);
+    addEnvironment(context, "zipkin.collector.eventhub.storage.blob-prefix:" + storageBlobPrefix);
     context.register(PropertyPlaceholderAutoConfiguration.class,
         EventHubCollectorAutoConfiguration.class,
         InMemoryConfiguration.class);
     context.refresh();
 
     EventHubCollectorProperties props = context.getBean(EventHubCollectorProperties.class);
-    assertEquals(storageBlobPrefix, props.getStorageBlobPrefix());
+    assertEquals(storageBlobPrefix, props.getStorage().getBlobPrefix());
   }
 
   @Test
-  public void provideCollectorComponent_canSetStorageContainerName() {
+  public void provideCollectorComponent_canSetStorageContainer() {
 
-    String storageContainerName = "pashmak";
+    String storageContainer = "pashmak";
 
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
-        "zipkin.collector.eventhub.eventHubConnectionString:" + dummyEventHubConnectionString);
+        "zipkin.collector.eventhub.connection-string:" + dummyConnectionString);
     addEnvironment(context,
-        "zipkin.collector.eventhub.storageConnectionString:" + dummyStorageConnectionString);
+        "zipkin.collector.eventhub.storage.connection-string:" + dummyStorageConnectionString);
     addEnvironment(context,
-        "zipkin.collector.eventhub.storageContainerName:" + storageContainerName);
+        "zipkin.collector.eventhub.storage.container:" + storageContainer);
     context.register(PropertyPlaceholderAutoConfiguration.class,
         EventHubCollectorAutoConfiguration.class,
         InMemoryConfiguration.class);
     context.refresh();
 
     EventHubCollectorProperties props = context.getBean(EventHubCollectorProperties.class);
-    assertEquals(storageContainerName, props.getStorageContainerName());
+    assertEquals(storageContainer, props.getStorage().getContainer());
   }
 
   @Test
@@ -186,9 +186,9 @@ public class EventHubCollectorAutoConfigurationTest {
 
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
-        "zipkin.collector.eventhub.eventHubConnectionString:" + dummyEventHubConnectionString);
+        "zipkin.collector.eventhub.connection-string:" + dummyConnectionString);
     addEnvironment(context,
-        "zipkin.collector.eventhub.storageConnectionString:" + dummyStorageConnectionString);
+        "zipkin.collector.eventhub.storage.connection-string:" + dummyStorageConnectionString);
     addEnvironment(context,
         "zipkin.collector.eventhub.checkpoint-batch-size:" + checkpointBatchSize);
     context.register(PropertyPlaceholderAutoConfiguration.class,

--- a/collector/eventhub/src/main/java/zipkin/collector/eventhub/EventHubCollector.java
+++ b/collector/eventhub/src/main/java/zipkin/collector/eventhub/EventHubCollector.java
@@ -33,56 +33,55 @@ public final class EventHubCollector implements CollectorComponent {
 
   public static final class Builder implements CollectorComponent.Builder {
     Collector.Builder delegate = Collector.builder(EventHubCollector.class);
-    String eventHubName = "zipkin";
-    String consumerGroupName = "$Default";
-    String eventHubConnectionString;
-    String storageConnectionString;
-    String storageContainerName = "zipkin";
+    String name = "zipkin";
+    String consumerGroup = "$Default";
+    String connectionString;
+    String processorHost = UUID.randomUUID().toString();
     int checkpointBatchSize = 10;
-
-    String processorHostName = UUID.randomUUID().toString();
-    String storageBlobPrefix = processorHostName;
+    String storageConnectionString;
+    String storageContainer = "zipkin";
+    String storageBlobPrefix = processorHost;
 
     Builder() {
     }
 
-    public Builder eventHubName(String name) {
-      eventHubName = name;
+    public Builder name(String name) {
+      this.name = name;
       return this;
     }
 
-    public Builder consumerGroupName(String name) {
-      consumerGroupName = name;
+    public Builder consumerGroup(String name) {
+      this.consumerGroup = name;
       return this;
     }
 
     public Builder checkpointBatchSize(int size) {
-      checkpointBatchSize = size;
+      this.checkpointBatchSize = size;
       return this;
     }
 
-    public Builder eventHubConnectionString(String connectionString) {
-      eventHubConnectionString = connectionString;
+    public Builder connectionString(String connectionString) {
+      this.connectionString = connectionString;
       return this;
     }
 
-    public Builder storageConnectionString(String connectionString) {
-      storageConnectionString = connectionString;
+    public Builder storageConnectionString(String storageConnectionString) {
+      this.storageConnectionString = storageConnectionString;
       return this;
     }
 
-    public Builder storageContainerName(String containerName) {
-      storageContainerName = containerName;
+    public Builder storageContainer(String storageContainer) {
+      this.storageContainer = storageContainer;
       return this;
     }
 
-    public Builder storageBlobPrefix(String blobPrefix) {
-      storageBlobPrefix = blobPrefix;
+    public Builder storageBlobPrefix(String storageBlobPrefix) {
+      this.storageBlobPrefix = storageBlobPrefix;
       return this;
     }
 
-    public Builder processorHostName(String nameForThisProcessorHost) {
-      processorHostName = nameForThisProcessorHost;
+    public Builder processorHost(String processorHost) {
+      this.processorHost = processorHost;
       return this;
     }
 

--- a/collector/eventhub/src/main/java/zipkin/collector/eventhub/LazyRegisterEventProcessor.java
+++ b/collector/eventhub/src/main/java/zipkin/collector/eventhub/LazyRegisterEventProcessor.java
@@ -32,12 +32,12 @@ class LazyRegisterEventProcessor extends LazyCloseable<Future<?>> {
 
   LazyRegisterEventProcessor(EventHubCollector.Builder builder) {
     host = new EventProcessorHost(
-        builder.processorHostName,
-        builder.eventHubName,
-        builder.consumerGroupName,
-        builder.eventHubConnectionString,
+        builder.processorHost,
+        builder.name,
+        builder.consumerGroup,
+        builder.connectionString,
         builder.storageConnectionString,
-        builder.storageContainerName,
+        builder.storageContainer,
         builder.storageBlobPrefix
     );
     ZipkinEventProcessor processor =

--- a/collector/eventhub/src/test/java/zipkin/collector/eventhub/LazyRegisterEventProcessorTest.java
+++ b/collector/eventhub/src/test/java/zipkin/collector/eventhub/LazyRegisterEventProcessorTest.java
@@ -151,7 +151,7 @@ public class LazyRegisterEventProcessorTest {
   class TestLazyRegisterEventProcessor extends LazyRegisterEventProcessor {
     TestLazyRegisterEventProcessor() {
       super(EventHubCollector.builder()
-          .eventHubConnectionString(
+          .connectionString(
               "endpoint=sb://someurl.net;SharedAccessKeyName=dumbo;SharedAccessKey=uius7y8ewychsih")
           .storageConnectionString("UseDevelopmentStorage=true")
           .storage(new InMemoryStorage()));


### PR DESCRIPTION
This shortens property names by removing filler suffixes like Name and
removing words already in the property namespace. This nests the storage
properties under their own namespace as well.

Finally, this encourages the more commonly used hyphen-case when people
create properties files.