### PR TITLE
Prefers very explicit name for the event processor factory registration

### DIFF
--- a/collector/eventhub/src/main/java/zipkin/collector/eventhub/EventHubCollector.java
+++ b/collector/eventhub/src/main/java/zipkin/collector/eventhub/EventHubCollector.java
@@ -106,25 +106,25 @@ public final class EventHubCollector implements CollectorComponent {
   }
 
   final AtomicBoolean closed = new AtomicBoolean(false);
-  final LazyCloseable<Future<?>> lazyRegisterEventProcessor;
+  final LazyCloseable<Future<?>> lazyRegisterEventProcessorFactoryWithHost;
 
   EventHubCollector(Builder builder) {
-    this(new LazyRegisterEventProcessor(builder));
+    this(new LazyRegisterEventProcessorFactoryWithHost(builder));
   }
 
-  EventHubCollector(LazyCloseable<Future<?>> lazyRegisterEventProcessor) {
-    this.lazyRegisterEventProcessor = lazyRegisterEventProcessor;
+  EventHubCollector(LazyCloseable<Future<?>> lazyRegisterEventProcessorFactoryWithHost) {
+    this.lazyRegisterEventProcessorFactoryWithHost = lazyRegisterEventProcessorFactoryWithHost;
   }
 
   @Override public EventHubCollector start() {
-    if (!closed.get()) lazyRegisterEventProcessor.get();
+    if (!closed.get()) lazyRegisterEventProcessorFactoryWithHost.get();
     return this;
   }
 
   @Override public CheckResult check() {
     try {
       // make sure compute doesn't throw an exception
-      Future<?> registrationFuture = lazyRegisterEventProcessor.get();
+      Future<?> registrationFuture = lazyRegisterEventProcessorFactoryWithHost.get();
       registrationFuture.get(); // make sure registration succeeded
       return CheckResult.OK;
     } catch (RuntimeException e) {
@@ -141,6 +141,6 @@ public final class EventHubCollector implements CollectorComponent {
 
   @Override public void close() throws IOException {
     if (!closed.compareAndSet(false, true)) return;
-    lazyRegisterEventProcessor.close();
+    lazyRegisterEventProcessorFactoryWithHost.close();
   }
 }

--- a/collector/eventhub/src/main/java/zipkin/collector/eventhub/LazyRegisterEventProcessorFactoryWithHost.java
+++ b/collector/eventhub/src/main/java/zipkin/collector/eventhub/LazyRegisterEventProcessorFactoryWithHost.java
@@ -22,15 +22,15 @@ import java.util.concurrent.Future;
 import zipkin.internal.LazyCloseable;
 
 /**
- * This registers an event processor on the first call to get {@link #get()}. If an event processor
- * was registered, it is deregistered on {@link #close()}.
+ * This registers an event processor factory on the first call to get {@link #get()}. If an event
+ * processor factory was registered, it is deregistered on {@link #close()}.
  */
 // not final for testing
-class LazyRegisterEventProcessor extends LazyCloseable<Future<?>> {
+class LazyRegisterEventProcessorFactoryWithHost extends LazyCloseable<Future<?>> {
   final EventProcessorHost host;
   final IEventProcessorFactory<?> factory;
 
-  LazyRegisterEventProcessor(EventHubCollector.Builder builder) {
+  LazyRegisterEventProcessorFactoryWithHost(EventHubCollector.Builder builder) {
     host = new EventProcessorHost(
         builder.processorHost,
         builder.name,
@@ -60,7 +60,7 @@ class LazyRegisterEventProcessor extends LazyCloseable<Future<?>> {
     if (maybeNull == null) return;
     try {
       maybeNull.cancel(true);
-      unregisterEventProcessorFromHost();
+      unregisterEventProcessorFactoryFromHost();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       InterruptedIOException toThrow =
@@ -77,7 +77,7 @@ class LazyRegisterEventProcessor extends LazyCloseable<Future<?>> {
     return host.registerEventProcessorFactory(factory);
   }
 
-  void unregisterEventProcessorFromHost() throws InterruptedException, ExecutionException {
+  void unregisterEventProcessorFactoryFromHost() throws InterruptedException, ExecutionException {
     host.unregisterEventProcessor();
   }
 }

--- a/collector/eventhub/src/test/java/zipkin/collector/eventhub/LazyRegisterEventProcessorFactoryWithHostTest.java
+++ b/collector/eventhub/src/test/java/zipkin/collector/eventhub/LazyRegisterEventProcessorFactoryWithHostTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.core.Is.is;
 
-public class LazyRegisterEventProcessorTest {
+public class LazyRegisterEventProcessorFactoryWithHostTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -37,7 +37,8 @@ public class LazyRegisterEventProcessorTest {
 
   @Test
   public void get_registersFactory() throws Exception {
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor();
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost();
 
     lazy.get();
 
@@ -47,7 +48,8 @@ public class LazyRegisterEventProcessorTest {
   @Test
   public void get_doesntWrapRuntimeException() throws Exception {
     RuntimeException exception = new RuntimeException("Failure initializing Storage lease manager");
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor() {
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost() {
       @Override Future<?> registerEventProcessorFactoryWithHost() throws Exception {
         throw exception;
       }
@@ -59,7 +61,8 @@ public class LazyRegisterEventProcessorTest {
 
   @Test
   public void get_wrapsCheckedException() throws Exception {
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor() {
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost() {
       @Override Future<?> registerEventProcessorFactoryWithHost() throws InvalidKeyException {
         throw new InvalidKeyException();
       }
@@ -72,7 +75,8 @@ public class LazyRegisterEventProcessorTest {
 
   @Test
   public void close_unregistersFactoryWhenOpen() throws Exception {
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor();
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost();
 
     lazy.get();
     lazy.close();
@@ -82,7 +86,8 @@ public class LazyRegisterEventProcessorTest {
 
   @Test
   public void close_doesntUnregisterFactoryWhenNotYetOpen() throws Exception {
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor();
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost();
 
     lazy.close();
 
@@ -91,7 +96,8 @@ public class LazyRegisterEventProcessorTest {
 
   @Test
   public void close_cancelsPendingRegistration() throws Exception {
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor() {
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost() {
       @Override Future<?> registerEventProcessorFactoryWithHost() throws InvalidKeyException {
         return registration; // note: we aren't setting this done!
       }
@@ -107,8 +113,9 @@ public class LazyRegisterEventProcessorTest {
   @Test
   public void close_doesntWrapRuntimeException() throws Exception {
     RuntimeException exception = new RuntimeException("Failure initializing Storage lease manager");
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor() {
-      @Override void unregisterEventProcessorFromHost() {
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost() {
+      @Override void unregisterEventProcessorFactoryFromHost() {
         throw exception;
       }
     };
@@ -120,8 +127,9 @@ public class LazyRegisterEventProcessorTest {
 
   @Test
   public void close_UnwrapsExecutionException() throws Exception {
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor() {
-      @Override void unregisterEventProcessorFromHost() throws ExecutionException {
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost() {
+      @Override void unregisterEventProcessorFactoryFromHost() throws ExecutionException {
         throw new ExecutionException(new RuntimeException());
       }
     };
@@ -133,8 +141,9 @@ public class LazyRegisterEventProcessorTest {
 
   @Test
   public void close_wrapsInterruptedAndSetsFlag() throws Exception {
-    LazyRegisterEventProcessor lazy = new TestLazyRegisterEventProcessor() {
-      @Override void unregisterEventProcessorFromHost() throws InterruptedException {
+    LazyRegisterEventProcessorFactoryWithHost
+        lazy = new TestLazyRegisterEventProcessorFactoryWithHost() {
+      @Override void unregisterEventProcessorFactoryFromHost() throws InterruptedException {
         throw new InterruptedException();
       }
     };
@@ -148,8 +157,9 @@ public class LazyRegisterEventProcessorTest {
     }
   }
 
-  class TestLazyRegisterEventProcessor extends LazyRegisterEventProcessor {
-    TestLazyRegisterEventProcessor() {
+  class TestLazyRegisterEventProcessorFactoryWithHost
+      extends LazyRegisterEventProcessorFactoryWithHost {
+    TestLazyRegisterEventProcessorFactoryWithHost() {
       super(EventHubCollector.newBuilder()
           .connectionString(
               "endpoint=sb://someurl.net;SharedAccessKeyName=dumbo;SharedAccessKey=uius7y8ewychsih")
@@ -162,7 +172,7 @@ public class LazyRegisterEventProcessorTest {
       return registration;
     }
 
-    @Override void unregisterEventProcessorFromHost()
+    @Override void unregisterEventProcessorFactoryFromHost()
         throws InterruptedException, ExecutionException {
       unregistered.set(true);
     }


### PR DESCRIPTION
The previous name bothered @aliostad

Fixes #12