### PR TITLE
Fixes checkpoint logic and backfills concurrency tests

### DIFF
--- a/collector/eventhub/src/test/java/zipkin/collector/eventhub/LazyRegisterEventProcessorFactoryWithHostTest.java
+++ b/collector/eventhub/src/test/java/zipkin/collector/eventhub/LazyRegisterEventProcessorFactoryWithHostTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -27,6 +28,7 @@ import zipkin.storage.InMemoryStorage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class LazyRegisterEventProcessorFactoryWithHostTest {
   @Rule
@@ -34,6 +36,11 @@ public class LazyRegisterEventProcessorFactoryWithHostTest {
 
   CompletableFuture<Object> registration = new CompletableFuture<>();
   AtomicBoolean unregistered = new AtomicBoolean();
+
+  /** Calling this ensures the main thread's interrupt status isn't tainted */
+  @After public void uninterrupt(){
+    Thread.currentThread().interrupted();
+  }
 
   @Test
   public void get_registersFactory() throws Exception {


### PR DESCRIPTION
This fixes the checkpoint logic, and backfills tests. Since we currently
don't know if callbacks are always on a different thread, this assumes
they will be. If someone from microsoft can confirm that callbacks are
always on the same thread, we can remove a lot of defense.

Fixes #16