### PR TITLE
Avoids zipkin internal classes and shades where impossible

### DIFF
--- a/collector/eventhub/pom.xml
+++ b/collector/eventhub/pom.xml
@@ -60,4 +60,48 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <!-- unhook direct dependence on internal classes -->
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <minimizeJar>true</minimizeJar>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <includes>
+                  <include>io.zipkin.java:zipkin</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <!-- Shade references to classes packages -->
+                  <artifact>io.zipkin.java:zipkin</artifact>
+                  <includes>
+                    <include>zipkin/internal/Lazy*.class</include>
+                  </includes>
+                  <excludes>
+                    <exclude>*</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>zipkin.internal</pattern>
+                  <shadedPattern>zipkin.collector.eventhub.internal.zipkin</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.0.21</version>
+            <version>2.1.0</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -205,7 +205,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.15</version>
+        <version>1.16</version>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>


### PR DESCRIPTION
We'll soon start supporting zipkin v2. This begins the decoupling from
v1 internals.